### PR TITLE
clickThrough bug in google chrome

### DIFF
--- a/lib/jquery.pikachoose.full.js
+++ b/lib/jquery.pikachoose.full.js
@@ -109,7 +109,7 @@ this.scroll(((this.options.wrap=='both'||this.options.wrap=='first')&&this.optio
 			//user passed a data source
 			e = $("<ul></ul>").appendTo(e);
 			$.each(this.options.data,function(){
-				var tmp = $("<li><a 'href='"+this.link+"'><img src='"+this.image+"'></a></li>").appendTo(e);
+				var tmp = $("<li><a href='"+this.link+"'><img src='"+this.image+"'></a></li>").appendTo(e);
 				if(typeof(this.title) != "undefined"){ tmp.find('a').attr('title',this.title); }
 				if(typeof(this.caption) != "undefined"){ tmp.append("<span>"+this.caption+"</span>"); }
 				if(typeof(this.thumbnail) != "undefined"){ tmp.find('a').attr('ref',this.thumbnail); }


### PR DESCRIPTION
in chrome, the single quote was becoming part of the attribute value, 
so line 181 'clickThrough':this.active.parent().attr('href') was
comming up null and click trough link was not getting set 
